### PR TITLE
showanswer waffle switch after course created

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -123,12 +123,14 @@ from ..utils import (
 )
 from .component import ADVANCED_COMPONENT_TYPES
 # Modified import to include get_default_end_date
+# Modified import to include get_default_end_date and ENABLE_DEFAULT_SHOWANSWER_NEVER
 try:
-    from custom_extensions.waffle import get_default_start_date as get_dynamic_start_date, get_grading_policy, get_default_end_date
+    from custom_extensions.waffle import get_default_start_date as get_dynamic_start_date, get_grading_policy, get_default_end_date, ENABLE_DEFAULT_SHOWANSWER_NEVER
 except Exception as e:
     get_dynamic_start_date = None
     get_grading_policy = None
     get_default_end_date = None
+    ENABLE_DEFAULT_SHOWANSWER_NEVER = None
 
 log = logging.getLogger(__name__)
 User = get_user_model()
@@ -1015,13 +1017,21 @@ def create_new_course_in_store(store, user, org, number, run, fields):
         'language': getattr(settings, 'DEFAULT_COURSE_LANGUAGE', 'en'),
         'cert_html_view_enabled': True,
     })
-    # Added by TitanEd ,updated to include end date
+
+    # Set default showanswer value based on waffle switch
+    if ENABLE_DEFAULT_SHOWANSWER_NEVER:
+        fields.update({
+            'showanswer': 'never' if ENABLE_DEFAULT_SHOWANSWER_NEVER.is_enabled() else 'finished'
+        })
+
+    # Added by TitanEd, updated to include end date
     if get_dynamic_start_date and get_grading_policy and get_default_end_date:
         fields.update({
             'start': get_dynamic_start_date(),
             'end': get_default_end_date(),
             'grading_policy': get_grading_policy(),
         })
+
     with modulestore().default_store(store):
         # Creating the course raises DuplicateCourseError if an existing course with this org/name is found
         new_course = modulestore().create_course(


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:

- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
